### PR TITLE
Enable Region specific Opsworks commands

### DIFF
--- a/bin/opsworks
+++ b/bin/opsworks
@@ -23,7 +23,7 @@ var argv    = require('yargs')
     })
     .boolean('i').alias('i', 'instances').describe('i','Show instances affected by deployment').default('i',false)
     .option('n', {
-      description: 'Number of deployments to display per stack'      
+      description: 'Number of deployments to display per stack'
     })
     .number('n')
     .default('n',5);
@@ -96,7 +96,13 @@ var argv    = require('yargs')
   .help('h')
   .boolean('v').alias('v', 'verbose').describe('v','Turns on verbose mode').default('v',false).global('v')
   .boolean('y').alias('y', 'yes').describe('y','Automatic yes to prompts, to run non-interactively').default('y',false).global('y')
+  .option('r', {
+    alias: 'region',
+    type: 'string',
+    describe: 'Specify a region specific stack'
+  })
   .example("deployments -f 'stack:production-*'",'List deployments for all production stacks')
+  .example("stacks -r 'us-east-1'",'List stacks for the us-east1 region')
   .example("recipes common::setup_users",'Execute setup_users on all your stacks')
   .example("setup -f layer:webapp,env:production",'Runs the setup deployment on "webapp" production layers')
   .argv;

--- a/lib/Opsworks.js
+++ b/lib/Opsworks.js
@@ -2,10 +2,17 @@
 
 var Logger        = require('./logger');
 var AWS           = require('aws-sdk');
-AWS.config.region = 'us-east-1';
 
 class Opsworks {
-  constructor() {
+  constructor(region) {
+    if (region !== undefined) {
+      AWS.config.region = region;
+    } else {
+      AWS.config.region = 'us-east-1';
+    }
+
+    Logger.debug("Setting Opsworks region to " + AWS.config.region);
+
     this.aws = new AWS.OpsWorks();
   }
 
@@ -21,13 +28,13 @@ class Opsworks {
   runCommands(stacks,type,args) {
     if(!stacks.length)
       throw new Error("No stacks matching your filters");
-    
+
     Logger.info(`Running command ${type} on ${stacks.length} stacks`);
 
     var p = [];
     var StackById = {};
 
-    stacks.forEach(stack => { 
+    stacks.forEach(stack => {
       StackById[stack.StackId] = stack;
       p.push(this.runCommand(stack,type,args))
     });
@@ -66,7 +73,7 @@ class Opsworks {
 
     var layers = [];
     var layersNames = [];
-    stack.layers.forEach(layer => { 
+    stack.layers.forEach(layer => {
       layers.push(layer.LayerId)
       layersNames.push(layer.Shortname);
     });
@@ -284,9 +291,9 @@ class Opsworks {
 
   /**
    * Given a list of stacks with layers, instances and ELBs,
-   * Match the instance IDs of the ELB with the "friendly" names 
+   * Match the instance IDs of the ELB with the "friendly" names
    * used in the opsworks stack.
-   *  
+   *
    * @param  {array} stacks
    * @return {array} stacks
    */
@@ -324,7 +331,7 @@ class Opsworks {
       var foundStack = null;
       stacks.forEach(stack => {
         if(stack.Name == name) {
-          foundStack = stack; 
+          foundStack = stack;
           return;
         }
       });

--- a/lib/commandrunner.js
+++ b/lib/commandrunner.js
@@ -12,7 +12,7 @@ class CommandRunner {
     this.argv = argv;
     this.hierarchy = new hierarchy(argv);
     Logger.debug("Argv : ",this.argv);
-    this.OpsWorks = new OpsWorks();
+    this.OpsWorks = new OpsWorks(this.argv.r);
 
     if(argv.v) {
       Logger.transports.console.level = 'debug';
@@ -25,7 +25,7 @@ class CommandRunner {
    * If a command is specified, called the associated method
    *   Ex: `stacks` calls stacks()
    * Otherwise, call runCli() to get the interactive cli
-   * 
+   *
    * @return {void}
    */
   runCommand() {
@@ -223,7 +223,7 @@ class CommandRunner {
   prompt() {
     var prompt = new Prompt(this);
     return prompt.start();
-  }  
+  }
 
   askConfirmation(stacks) {
     if(this.argv.y) {


### PR DESCRIPTION
This change proposal is to address Issue #4. It has been lightly tested (in manual mode). I think for completeness it would still need unittests, but wanted to propose this as a solution before putting more time into the branch.